### PR TITLE
Update plugin information in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Default: `null`
 
 The browsers you would like to test.
 
-*With the exception of PhantomJS, you need to have the Dalek [browser plugin](https://github.com/dalekjs?query=dalek-browser0) installed.*
+*With the exception of PhantomJS, you need to have the corresponding Dalek [browser plugins](https://github.com/dalekjs?query=dalek-browser) installed.*
 
 ##### reporter
 
@@ -52,7 +52,7 @@ Default: `null`
 
 The reporters you would like to invoke
 
-*With the exception of console output, you need to have the Dalek [reporter plugin](https://github.com/dalekjs?query=dalek-reporter) installed.*
+*With the exception of console output, you need to have the corresponding Dalek [reporter plugins](https://github.com/dalekjs?query=dalek-reporter) installed.*
 
 ## License
 &copy; 2014 GoInstant Inc., a salesforce.com company. Licensed under the BSD 3-clause license.


### PR DESCRIPTION
The instructions threw me off initially because I thought that there was only one browser plugin, when there are several you can install depending on your config. I updated the wording to reflect this. I also fixed the browser plugin URL.

Fixed url to browser plugins and clarified that you may need to install more than one