### PR TITLE
Fix syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gulp.task('test', function() {
     .pipe(dalek({
       browser: ['phantomjs', 'chrome', 'chrome:canary'],
       reporter: ['html', 'junit']
-    });
+    }));
 });
 
 ```


### PR DESCRIPTION
Syntax error in usage example. Results in a gruntfile.js parsing error.
